### PR TITLE
Add HLW811X device initialization and communication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ dkms.conf
 .cache
 build/
 compile_commands.json
+cpputest

--- a/hlw811x.c
+++ b/hlw811x.c
@@ -5,7 +5,6 @@
  */
 
 #include "hlw811x.h"
-#include "hlw811x_regs.h"
 #include "hlw811x_overrides.h"
 
 #if !defined(HLW811X_MCLK)
@@ -30,6 +29,14 @@ enum {
 	CMD_RESET_CHIP		= 0x96u,
 };
 
+typedef size_t (*encoder_t)(uint8_t *buf, size_t bufsize,
+		const uint8_t *data, size_t datalen);
+typedef size_t (*decoder_t)(uint8_t *buf, size_t bufsize,
+		const uint8_t *tx, size_t tx_len,
+		const uint8_t *rx, size_t rx_len);
+
+static hlw811x_interface_t iface;
+
 static int32_t convert_24bit_to_int32(const int32_t value)
 {
 	int32_t result = value;
@@ -41,10 +48,62 @@ static int32_t convert_24bit_to_int32(const int32_t value)
 	return (int32_t)result;
 }
 
-static hlw811x_error_t write_reg(hlw811x_reg_addr_t addr,
+static size_t encode_uart(uint8_t *buf, size_t bufsize,
 		const uint8_t *data, size_t datalen)
 {
-	uint8_t txbuf[3] = { addr | 0x80u, 0, 0 };
+	if (bufsize < datalen + 2) {
+		HLW811X_ERROR("Buffer size is too small");
+		return 0;
+	}
+
+	buf[0] = 0xA5;
+	uint8_t chksum = buf[0];
+
+	for (size_t i = 0; i < datalen; i++) {
+		buf[i + 1] = data[i];
+		chksum += data[i];
+	}
+	buf[datalen + 1] = ~chksum;
+
+	return datalen + 2;
+}
+
+static size_t decode_uart(uint8_t *buf, size_t bufsize,
+		const uint8_t *tx, size_t tx_len,
+		const uint8_t *rx, size_t rx_len)
+{
+	if (tx_len < 1) {
+		HLW811X_ERROR("Invalid tx_len");
+		return 0;
+	}
+
+	if (rx_len < 3 || bufsize < rx_len - 1) {
+		HLW811X_ERROR("Invalid rx_len");
+		return 0;
+	}
+
+	uint8_t chksum = tx[tx_len - 1];
+
+	for (size_t i = 0; i < rx_len - 1; i++) {
+		buf[i] = rx[i];
+		chksum += rx[i];
+	}
+
+	if ((uint8_t)~chksum != rx[rx_len - 1]) {
+		HLW811X_ERROR("Checksum mismatch %x : %x",
+				~chksum, rx[rx_len - 1]);
+		return 0;
+	}
+
+	return rx_len - 1;
+}
+
+static hlw811x_error_t send_frame(hlw811x_reg_addr_t addr,
+		const uint8_t *data, size_t datalen)
+{
+	uint8_t payload[3] = { (uint8_t)addr, 0, 0 };
+	uint8_t txbuf[sizeof(payload) + 2] = { 0, };
+	encoder_t encoder = encode_uart;
 
 	if (datalen > 2 || (data == NULL && datalen != 0)) {
 		HLW811X_ERROR("Invalid parameter");
@@ -52,10 +111,18 @@ static hlw811x_error_t write_reg(hlw811x_reg_addr_t addr,
 	}
 
 	for (size_t i = 0; i < datalen; i++) {
-		txbuf[i + 1] = data[i];
+		payload[i + 1] = data[i];
 	}
 
-	if (hlw811x_ll_write(txbuf, datalen+1) != 0) {
+	if (iface == HLW811X_UART) {
+	} else {
+		HLW811X_ERROR("Not implemented");
+		return HLW811X_NOT_IMPLEMENTED;
+	}
+
+	const size_t len = (*encoder)(txbuf, sizeof(txbuf), payload, datalen+1);
+
+	if (hlw811x_ll_write(txbuf, len) != 0) {
 		HLW811X_ERROR("hlw811x_ll_write() failed");
 		return HLW811X_IO_ERROR;
 	}
@@ -63,22 +130,42 @@ static hlw811x_error_t write_reg(hlw811x_reg_addr_t addr,
 	return HLW811X_ERROR_NONE;
 }
 
+static hlw811x_error_t write_reg(hlw811x_reg_addr_t addr,
+		const uint8_t *data, size_t datalen)
+{
+	return send_frame((uint8_t)(addr | 0x80u), data, datalen);
+}
+
 static hlw811x_error_t read_reg(hlw811x_reg_addr_t addr,
 		uint8_t *buf, size_t bytes_to_read)
 {
-	hlw811x_error_t err = write_reg(addr, 0, 0);
+	hlw811x_error_t err;
+	int rc;
+	size_t len;
+	uint8_t rxbuf[bytes_to_read + 3];
+	uint8_t txbuf[3];
+	encoder_t encoder = encode_uart;
+	decoder_t decoder = decode_uart;
 
-	if (err != HLW811X_ERROR_NONE) {
+	if ((err = send_frame(addr, 0, 0)) != HLW811X_ERROR_NONE) {
 		return err;
 	}
 
-	int rc = hlw811x_ll_read(buf, bytes_to_read);
-
-	if (rc < 0) {
+	if ((rc = hlw811x_ll_read(rxbuf, sizeof(rxbuf))) < 0) {
 		HLW811X_ERROR("hlw811x_ll_read() failed");
 		return HLW811X_IO_ERROR;
-	} else if (rc != (int)bytes_to_read) {
-		HLW811X_ERROR("hlw811x_ll_read() returned %d", rc);
+	}
+
+	if (iface == HLW811X_UART) {
+	} else {
+		HLW811X_ERROR("Not implemented");
+		return HLW811X_NOT_IMPLEMENTED;
+	}
+
+	len = (*encoder)(txbuf, sizeof(txbuf), (uint8_t *)&addr, 1);
+	if ((len = (*decoder)(buf, bytes_to_read,
+			txbuf, len, rxbuf, (size_t)rc)) != bytes_to_read) {
+		HLW811X_ERROR("decoder returned %d", len);
 		return HLW811X_INCORRECT_RESPONSE;
 	}
 
@@ -87,30 +174,53 @@ static hlw811x_error_t read_reg(hlw811x_reg_addr_t addr,
 
 static hlw811x_error_t reset_chip(void)
 {
-	uint8_t cmd = CMD_RESET_CHIP;
+	const uint8_t cmd = CMD_RESET_CHIP;
 	return write_reg(HLW811X_REG_COMMAND, &cmd, 1);
 }
 
 static hlw811x_error_t enable_write(void)
 {
-	uint8_t cmd = CMD_ENABLE_WRITE;
+	const uint8_t cmd = CMD_ENABLE_WRITE;
 	return write_reg(HLW811X_REG_COMMAND, &cmd, 1);
 }
 
 static hlw811x_error_t disable_write(void)
 {
-	uint8_t cmd = CMD_DISABLE_WRITE;
+	const uint8_t cmd = CMD_DISABLE_WRITE;
 	return write_reg(HLW811X_REG_COMMAND, &cmd, 1);
 }
 
 static hlw811x_error_t select_channel(hlw811x_channel_t channel)
 {
-	uint8_t cmd = (channel == HLW811X_CHANNEL_A)?
+	const uint8_t cmd = (channel == HLW811X_CHANNEL_A)?
 		CMD_SET_CHANNEL_A : CMD_SET_CHANNEL_B;
 	return write_reg(HLW811X_REG_COMMAND, &cmd, 1);
 }
 
-hlw811x_error_t hlw811x_init(void)
+hlw811x_error_t hlw811x_write_reg(hlw811x_reg_addr_t addr,
+		const uint8_t *data, size_t datalen)
+{
+	return write_reg(addr, data, datalen);
+}
+
+hlw811x_error_t hlw811x_read_reg(hlw811x_reg_addr_t addr,
+		uint8_t *buf, size_t bufsize)
+{
+	return read_reg(addr, buf, bufsize);
+}
+
+hlw811x_error_t hlw811x_select_channel(hlw811x_channel_t channel)
+{
+	return select_channel(channel);
+}
+
+hlw811x_error_t hlw811x_reset(void)
 {
 	return reset_chip();
+}
+
+hlw811x_error_t hlw811x_init(hlw811x_interface_t interface)
+{
+	iface = interface;
+	return HLW811X_ERROR_NONE;
 }

--- a/hlw811x.h
+++ b/hlw811x.h
@@ -11,11 +11,16 @@
 extern "C" {
 #endif
 
+#include <stdint.h>
+#include <stddef.h>
+#include "hlw811x_regs.h"
+
 typedef enum {
 	HLW811X_ERROR_NONE,
 	HLW811X_INVALID_PARAM,
 	HLW811X_IO_ERROR,
 	HLW811X_INCORRECT_RESPONSE,
+	HLW811X_NOT_IMPLEMENTED,
 } hlw811x_error_t;
 
 typedef enum {
@@ -23,20 +28,45 @@ typedef enum {
 	HLW811X_CHANNEL_B,
 } hlw811x_channel_t;
 
+typedef enum {
+	HLW811X_UART,
+	HLW811X_SPI,
+} hlw811x_interface_t;
+
 /**
- * @brief Initializes the HLW811x chip.
+ * @brief Initializes the HLW811X device with the specified interface.
  *
- * This function is used to initialize the HLW811x chip. It does this by
- * calling the `reset_chip` function, which presumably resets the chip to
- * a known state.
+ * This function sets up the HLW811X device using the provided interface,
+ * preparing it for operation.
  *
- * @note At least 60ms delay is required after initialization before calling
- * any other functions because the chip needs time to stabilize such as crystal
- * oscillator start-up time.
+ * @param[in] interface The interface to be used.
  *
- * @return hlw811x_error_t
+ * @return hlw811x_error_t Returns an error code indicating the success or
+ *                         failure of the initialization.
  */
-hlw811x_error_t hlw811x_init(void);
+hlw811x_error_t hlw811x_init(hlw811x_interface_t interface);
+
+/**
+ * @brief Resets the HLW811X device.
+ *
+ * This function performs a reset operation on the HLW811X device,
+ * restoring it to its default state.
+ *
+ * @note At least 60ms delay is required after reset before calling any other
+ *       functions because the chip needs time to stabilize such as crystal
+ *       oscillator start-up time.
+ *
+ * @return hlw811x_error_t Returns an error code indicating the success or
+ *                         failure of the reset operation.
+ */
+hlw811x_error_t hlw811x_reset(void);
+
+hlw811x_error_t hlw811x_write_reg(hlw811x_reg_addr_t addr,
+		const uint8_t *data, size_t datalen);
+hlw811x_error_t hlw811x_read_reg(hlw811x_reg_addr_t addr,
+		uint8_t *buf, size_t bufsize);
+
+hlw811x_error_t hlw811x_select_channel(hlw811x_channel_t channel);
 
 #if defined(__cplusplus)
 }

--- a/hlw811x_overrides.h
+++ b/hlw811x_overrides.h
@@ -14,7 +14,29 @@ extern "C" {
 #include <stddef.h>
 #include <stdint.h>
 
+/**
+ * @brief Writes data to the HLW811X device at a low level.
+ *
+ * This function sends the specified data to the HLW811X device.
+ *
+ * @param[in] data Pointer to the data to be written.
+ * @param[in] datalen Length of the data to be written.
+ *
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
 int hlw811x_ll_write(const uint8_t *data, size_t datalen);
+
+/**
+ * @brief Reads data from the HLW811X device at a low level.
+ *
+ * This function reads data from the HLW811X device into the specified buffer.
+ *
+ * @param[out] buf Pointer to the buffer where the read data will be stored.
+ * @param[int] bufsize Size of the buffer.
+ *
+ * @return int Returns the number of bytes read on success, or a negative error
+ *             code on failure.
+ */
 int hlw811x_ll_read(uint8_t *buf, size_t bufsize);
 
 #if defined(__cplusplus)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,5 +1,3 @@
-# SPDX-License-Identifier: MIT
-
 export CPPUTEST_HOME = cpputest
 export TEST_BUILDIR ?= build
 

--- a/tests/runners/MakefileRunner
+++ b/tests/runners/MakefileRunner
@@ -1,5 +1,3 @@
-# SPDX-License-Identifier: MIT
-
 ifndef SILENCE
 SILENCE = @
 endif
@@ -52,15 +50,15 @@ export CPPUTEST_WARNINGFLAGS = \
 	-Wno-error=switch-enum \
 	-Wno-error=aggregate-return \
 
-#-Wredundant-decls -Wswitch-enum
-
 ifeq ($(shell uname), Darwin)
 CPPUTEST_WARNINGFLAGS += \
 	-Wno-error=zero-as-null-pointer-constant \
 	-Wno-error=poison-system-directories \
 	-Wno-error=covered-switch-default \
 	-Wno-error=format-nonliteral \
-	-Wno-error=pedantic
+	-Wno-error=pedantic \
+	-Wno-error=suggest-override \
+	-Wno-error=suggest-destructor-override
 else
 #TARGET_PLATFORM ?= $(shell gcc -dumpmachine)
 endif

--- a/tests/runners/hlw811x.mk
+++ b/tests/runners/hlw811x.mk
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: MIT
+
+COMPONENT_NAME = hlw811x
+
+SRC_FILES = \
+	../hlw811x.c
+
+TEST_SRC_FILES = \
+	src/hlw811x_test.cpp \
+	src/test_all.cpp \
+
+INCLUDE_DIRS = $(CPPUTEST_HOME)/include ../
+MOCKS_SRC_DIRS =
+CPPUTEST_CPPFLAGS = -Wno-error=unused-macros
+
+include runners/MakefileRunner

--- a/tests/src/hlw811x_test.cpp
+++ b/tests/src/hlw811x_test.cpp
@@ -1,0 +1,72 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Kyunghwan Kwon <k@libmcu.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "CppUTest/TestHarness.h"
+#include "CppUTest/TestHarness_c.h"
+#include "CppUTestExt/MockSupport.h"
+
+#include "hlw811x.h"
+#include "hlw811x_overrides.h"
+
+int hlw811x_ll_write(const uint8_t *data, size_t datalen) {
+	return mock().actualCall(__func__)
+		.withMemoryBufferParameter("data", data, datalen)
+		.returnIntValueOrDefault(0);
+}
+
+int hlw811x_ll_read(uint8_t *buf, size_t bufsize) {
+	return mock().actualCall(__func__)
+		.withOutputParameter("buf", buf)
+		.returnIntValueOrDefault(0);
+}
+
+TEST_GROUP(HLW811x) {
+	void setup(void) {
+		hlw811x_init(HLW811X_UART);
+	}
+	void teardown(void) {
+		mock().checkExpectations();
+		mock().clear();
+	}
+};
+
+TEST(HLW811x, reset_ShouldSendResetCommand) {
+	mock().expectOneCall("hlw811x_ll_write")
+		.withMemoryBufferParameter("data", (const uint8_t *)"\xA5\xEA\x96\xDA", 4)
+		.andReturnValue(0);
+	LONGS_EQUAL(HLW811X_ERROR_NONE, hlw811x_reset());
+}
+
+TEST(HLW811x, select_channel_ShouldSendChannelACommand_WhenChannelAIsSelected) {
+	mock().expectOneCall("hlw811x_ll_write")
+		.withMemoryBufferParameter("data", (const uint8_t *)"\xA5\xEA\x5A\x16", 4)
+		.andReturnValue(0);
+	LONGS_EQUAL(HLW811X_ERROR_NONE, hlw811x_select_channel(HLW811X_CHANNEL_A));
+}
+
+TEST(HLW811x, select_channel_ShouldSendChannelACommand_WhenChannelBIsSelected) {
+	mock().expectOneCall("hlw811x_ll_write")
+		.withMemoryBufferParameter("data", (const uint8_t *)"\xA5\xEA\xA5\xCB", 4)
+		.andReturnValue(0);
+	LONGS_EQUAL(HLW811X_ERROR_NONE, hlw811x_select_channel(HLW811X_CHANNEL_B));
+}
+
+TEST(HLW811x, write_reg_ShouldSendDataToSpecifiedRegister) {
+	mock().expectOneCall("hlw811x_ll_write")
+		.withMemoryBufferParameter("data", (const uint8_t *)"\xA5\x80\x0A\x04\xCC", 5)
+		.andReturnValue(0);
+	LONGS_EQUAL(HLW811X_ERROR_NONE, hlw811x_write_reg(HLW811X_REG_SYS_CTRL, (const uint8_t *)"\x0A\x04", 2));
+}
+
+TEST(HLW811x, read_reg_ShouldReadDataFromSpecifiedRegister) {
+	mock().expectOneCall("hlw811x_ll_write").ignoreOtherParameters().andReturnValue(0);
+	mock().expectOneCall("hlw811x_ll_read")
+		.withOutputParameterReturning("buf", (const uint8_t *)"\x0A\x04\x97", 3)
+		.andReturnValue(3);
+	uint8_t buf[2];
+	LONGS_EQUAL(HLW811X_ERROR_NONE, hlw811x_read_reg(HLW811X_REG_SYS_CTRL, buf, sizeof(buf)));
+	MEMCMP_EQUAL("\x0A\x04", buf, sizeof(buf));
+}


### PR DESCRIPTION
This pull request includes significant changes to the `hlw811x` library, focusing on adding UART communication support and enhancing the test infrastructure. The most important changes include adding new encoding/decoding functions, modifying register read/write operations, and updating the test framework to include new tests for these functionalities.

### Enhancements to UART communication:

* Added new functions `encode_uart` and `decode_uart` to handle UART communication encoding and decoding. (`hlw811x.c`)
* Introduced a new `hlw811x_interface_t` enum to specify the interface type (UART or SPI) and updated the initialization function to accept this parameter. (`hlw811x.h`, `hlw811x.c`) [[1]](diffhunk://#diff-21dcb5946cfc8c9963a6db1d7d47abcadd5f451ff3d9e8a1ef0f5bb95ca04f04R14-R69) [[2]](diffhunk://#diff-5d0610a8b7c534a9ee8924bb629ff29497744673dc8af8bfe3d901be71dcd0ccL90-R226)

### Modifications to register operations:

* Refactored `write_reg` and `read_reg` functions to use the new `send_frame` function, which handles the communication based on the interface type. (`hlw811x.c`) [[1]](diffhunk://#diff-5d0610a8b7c534a9ee8924bb629ff29497744673dc8af8bfe3d901be71dcd0ccL44-R168) [[2]](diffhunk://#diff-5d0610a8b7c534a9ee8924bb629ff29497744673dc8af8bfe3d901be71dcd0ccL90-R226)
* Added new public API functions `hlw811x_write_reg`, `hlw811x_read_reg`, `hlw811x_select_channel`, and `hlw811x_reset` to provide a more comprehensive interface for interacting with the device. (`hlw811x.h`, `hlw811x.c`) [[1]](diffhunk://#diff-21dcb5946cfc8c9963a6db1d7d47abcadd5f451ff3d9e8a1ef0f5bb95ca04f04R14-R69) [[2]](diffhunk://#diff-5d0610a8b7c534a9ee8924bb629ff29497744673dc8af8bfe3d901be71dcd0ccL90-R226)

### Test infrastructure updates:

* Created a new test suite for `hlw811x` using CppUTest, including tests for reset, channel selection, register write, and register read operations. (`tests/src/hlw811x_test.cpp`)
* Added a new makefile `hlw811x.mk` to manage the test build process. (`tests/runners/hlw811x.mk`)

### Miscellaneous changes:

* Removed unused include `hlw811x_regs.h` from `hlw811x.c`. (`hlw811x.c`)
* Added low-level read/write function declarations to `hlw811x_overrides.h`. (`hlw811x_overrides.h`)
* Renamed `tests/MakefileRunner.mk` to `tests/runners/MakefileRunner` and updated warning flags. (`tests/runners/MakefileRunner`) [[1]](diffhunk://#diff-9928d840550c78de306bd4851764fa7750be055de25c17f127bc9dcd399056ccL1-L2) [[2]](diffhunk://#diff-9928d840550c78de306bd4851764fa7750be055de25c17f127bc9dcd399056ccL55-R61)