### PR TITLE
Convert to multi-instance module

### DIFF
--- a/hlw811x.h
+++ b/hlw811x.h
@@ -137,17 +137,30 @@ struct hlw811x_pga {
 };
 
 /**
- * @brief Initializes the HLW811X device with the specified interface.
+ * @brief Create and initialize an HLW811X device instance.
  *
- * This function sets up the HLW811X device using the provided interface,
- * preparing it for operation.
+ * This function creates and initializes an HLW811X device instance with the
+ * specified interface and context.
  *
- * @param[in] interface The interface to be used.
+ * @param[in] interface The interface to be used for communication with the
+ *            HLW811X device.
+ * @param[in] ctx Pointer to the context or additional parameters required for
+ *            the interface.
  *
- * @return hlw811x_error_t Returns an error code indicating the success or
- *                         failure of the initialization.
+ * @return struct hlw811x* Pointer to the created HLW811X device instance, or
+ *         NULL on failure.
  */
-hlw811x_error_t hlw811x_init(hlw811x_interface_t interface);
+struct hlw811x *hlw811x_create(hlw811x_interface_t interface, void *ctx);
+
+/**
+ * @brief Destroy an HLW811X device instance.
+ *
+ * This function destroys the specified HLW811X device instance, freeing any
+ * resources that were allocated for it.
+ *
+ * @param[in] hlw811x Pointer to the HLW811X device instance to be destroyed.
+ */
+void hlw811x_destroy(struct hlw811x *hlw811x);
 
 /**
  * @brief Resets the HLW811X device.
@@ -159,10 +172,12 @@ hlw811x_error_t hlw811x_init(hlw811x_interface_t interface);
  *       functions because the chip needs time to stabilize such as crystal
  *       oscillator start-up time.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
+ *
  * @return hlw811x_error_t Returns an error code indicating the success or
  *                         failure of the reset operation.
  */
-hlw811x_error_t hlw811x_reset(void);
+hlw811x_error_t hlw811x_reset(struct hlw811x *self);
 
 /**
  * @brief Write data to a specified HLW811X register.
@@ -170,14 +185,15 @@ hlw811x_error_t hlw811x_reset(void);
  * This function writes the specified data to the HLW811X register at the given
  * address.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[in] addr The address of the HLW811X register to write to.
  * @param[in] data Pointer to the data to be written to the register.
  * @param[in] datalen Length of the data to be written.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_write_reg(hlw811x_reg_addr_t addr,
-		const uint8_t *data, size_t datalen);
+hlw811x_error_t hlw811x_write_reg(struct hlw811x *self,
+		hlw811x_reg_addr_t addr, const uint8_t *data, size_t datalen);
 
 /**
  * @brief Read data from a specified HLW811X register.
@@ -185,36 +201,41 @@ hlw811x_error_t hlw811x_write_reg(hlw811x_reg_addr_t addr,
  * This function reads data from the HLW811X register at the given address into
  * the specified buffer.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[in] addr The address of the HLW811X register to read from.
  * @param[out] buf Pointer to the buffer to store the read data.
  * @param[in] bufsize Size of the buffer.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_read_reg(hlw811x_reg_addr_t addr,
-		uint8_t *buf, size_t bufsize);
+hlw811x_error_t hlw811x_read_reg(struct hlw811x *self,
+		hlw811x_reg_addr_t addr, uint8_t *buf, size_t bufsize);
 
 /**
  * @brief Enable a specified HLW811X channel.
  *
  * This function enables the specified HLW811X channel for operation.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[in] channel The HLW811X channel to enable.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_enable_channel(hlw811x_channel_t channel);
+hlw811x_error_t hlw811x_enable_channel(struct hlw811x *self,
+		hlw811x_channel_t channel);
 
 /**
  * @brief Disable a specified HLW811X channel.
  *
  * This function disables the specified HLW811X channel, stopping its operation.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[in] channel The HLW811X channel to disable.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_disable_channel(hlw811x_channel_t channel);
+hlw811x_error_t hlw811x_disable_channel(struct hlw811x *self,
+		hlw811x_channel_t channel);
 
 /**
  * @brief Enable pulse output and energy accumulation for a specified channel.
@@ -222,11 +243,13 @@ hlw811x_error_t hlw811x_disable_channel(hlw811x_channel_t channel);
  * This function enables the pulse output and energy accumulation for the
  * specified HLW811X channel.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[in] channel The HLW811X channel to enable pulse output for.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_enable_pulse(hlw811x_channel_t channel);
+hlw811x_error_t hlw811x_enable_pulse(struct hlw811x *self,
+		hlw811x_channel_t channel);
 
 /**
  * @brief Disable pulse output and energy accumulation for a specified channel.
@@ -234,11 +257,13 @@ hlw811x_error_t hlw811x_enable_pulse(hlw811x_channel_t channel);
  * This function disables the pulse output and energy accumulation for the
  * specified HLW811X channel.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[in] channel The HLW811X channel to disable pulse output for.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_disable_pulse(hlw811x_channel_t channel);
+hlw811x_error_t hlw811x_disable_pulse(struct hlw811x *self,
+		hlw811x_channel_t channel);
 
 /**
  * @brief Enable waveform output.
@@ -246,9 +271,11 @@ hlw811x_error_t hlw811x_disable_pulse(hlw811x_channel_t channel);
  * This function enables the waveform output feature of the HLW811X,
  * allowing the waveform data to be output.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
+ *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_enable_waveform(void);
+hlw811x_error_t hlw811x_enable_waveform(struct hlw811x *self);
 
 /**
  * @brief Disable waveform output.
@@ -256,9 +283,11 @@ hlw811x_error_t hlw811x_enable_waveform(void);
  * This function disables the waveform output feature of the HLW811X,
  * stopping the waveform data from being output.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
+ *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_disable_waveform(void);
+hlw811x_error_t hlw811x_disable_waveform(struct hlw811x *self);
 
 /**
  * @brief Enable zero-crossing detection.
@@ -268,9 +297,11 @@ hlw811x_error_t hlw811x_disable_waveform(void);
  *
  * @note hlw811x_enable_waveform() must be enabled to use this functionality.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
+ *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_enable_zerocrossing(void);
+hlw811x_error_t hlw811x_enable_zerocrossing(struct hlw811x *self);
 
 /**
  * @brief Disable zero-crossing detection.
@@ -278,9 +309,11 @@ hlw811x_error_t hlw811x_enable_zerocrossing(void);
  * This function disables the zero-crossing detection feature of the HLW811X,
  * stopping the detection of zero-crossing points in the waveform.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
+ *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_disable_zerocrossing(void);
+hlw811x_error_t hlw811x_disable_zerocrossing(struct hlw811x *self);
 
 /**
  * @brief Enable power factor measurement.
@@ -288,9 +321,11 @@ hlw811x_error_t hlw811x_disable_zerocrossing(void);
  * This function enables the power factor measurement feature of the HLW811X,
  * allowing the measurement of the power factor.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
+ *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_enable_power_factor(void);
+hlw811x_error_t hlw811x_enable_power_factor(struct hlw811x *self);
 
 /**
  * @brief Disable power factor measurement.
@@ -298,9 +333,11 @@ hlw811x_error_t hlw811x_enable_power_factor(void);
  * This function disables the power factor measurement feature of the HLW811X,
  * stopping the measurement of the power factor.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
+ *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_disable_power_factor(void);
+hlw811x_error_t hlw811x_disable_power_factor(struct hlw811x *self);
 
 /**
  * @brief Enable energy clearance for a specified HLW811X channel.
@@ -309,11 +346,13 @@ hlw811x_error_t hlw811x_disable_power_factor(void);
  * channel, allowing the energy accumulation to be cleared after reading the
  * register.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[in] channel The HLW811X channel to enable energy clearance for.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_enable_energy_clearance(hlw811x_channel_t channel);
+hlw811x_error_t hlw811x_enable_energy_clearance(struct hlw811x *self,
+		hlw811x_channel_t channel);
 
 /**
  * @brief Disable energy clearance for a specified HLW811X channel.
@@ -321,11 +360,13 @@ hlw811x_error_t hlw811x_enable_energy_clearance(hlw811x_channel_t channel);
  * This function disables the energy clearance feature for the specified HLW811X
  * channel, preventing the energy accumulation from being cleared.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[in] channel The HLW811X channel to disable energy clearance for.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_disable_energy_clearance(hlw811x_channel_t channel);
+hlw811x_error_t hlw811x_disable_energy_clearance(struct hlw811x *self,
+		hlw811x_channel_t channel);
 
 /**
  * @brief Enable high-pass filter for a specified HLW811X channel.
@@ -333,11 +374,13 @@ hlw811x_error_t hlw811x_disable_energy_clearance(hlw811x_channel_t channel);
  * This function enables the high-pass filter (HPF) for the specified HLW811X
  * channel, which can help to remove DC components from the signal.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[in] channel The HLW811X channel to enable the high-pass filter for.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_enable_hpf(hlw811x_channel_t channel);
+hlw811x_error_t hlw811x_enable_hpf(struct hlw811x *self,
+		hlw811x_channel_t channel);
 
 /**
  * @brief Disable high-pass filter for a specified HLW811X channel.
@@ -345,11 +388,13 @@ hlw811x_error_t hlw811x_enable_hpf(hlw811x_channel_t channel);
  * This function disables the high-pass filter (HPF) for the specified HLW811X
  * channel, allowing DC components to pass through the signal.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[in] channel The HLW811X channel to disable the high-pass filter for.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_disable_hpf(hlw811x_channel_t channel);
+hlw811x_error_t hlw811x_disable_hpf(struct hlw811x *self,
+		hlw811x_channel_t channel);
 
 /**
  * @brief Enable B channel comparator.
@@ -371,9 +416,11 @@ hlw811x_error_t hlw811x_disable_hpf(hlw811x_channel_t channel);
  * @warn The external power of HLW811X must be disconnected and supply power to
  * HLW811X again after catching the interrupt to get it work properly.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
+ *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_enable_b_channel_comparator(void);
+hlw811x_error_t hlw811x_enable_b_channel_comparator(struct hlw811x *self);
 
 /**
  * @brief Disable B channel comparator.
@@ -381,9 +428,11 @@ hlw811x_error_t hlw811x_enable_b_channel_comparator(void);
  * This function disables the comparator for the B channel of the HLW811X,
  * preventing comparison operations on the B channel.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
+ *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_disable_b_channel_comparator(void);
+hlw811x_error_t hlw811x_disable_b_channel_comparator(struct hlw811x *self);
 
 /**
  * @brief Enable temperature sensor.
@@ -396,7 +445,7 @@ hlw811x_error_t hlw811x_disable_b_channel_comparator(void);
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_enable_temperature_sensor(void);
+hlw811x_error_t hlw811x_enable_temperature_sensor(struct hlw811x *self);
 
 /**
  * @brief Disable temperature sensor.
@@ -404,9 +453,11 @@ hlw811x_error_t hlw811x_enable_temperature_sensor(void);
  * This function disables the temperature sensor of the HLW811X,
  * preventing temperature measurements.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
+ *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_disable_temperature_sensor(void);
+hlw811x_error_t hlw811x_disable_temperature_sensor(struct hlw811x *self);
 
 /**
  * @brief Enable peak detection.
@@ -416,9 +467,11 @@ hlw811x_error_t hlw811x_disable_temperature_sensor(void);
  *
  * @note hlw811x_enable_waveform() must be enabled to use this functionality.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
+ *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_enable_peak_detection(void);
+hlw811x_error_t hlw811x_enable_peak_detection(struct hlw811x *self);
 
 /**
  * @brief Disable peak detection.
@@ -426,9 +479,11 @@ hlw811x_error_t hlw811x_enable_peak_detection(void);
  * This function disables the peak detection feature of the HLW811X,
  * preventing the detection of peak values in the channel signals.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
+ *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_disable_peak_detection(void);
+hlw811x_error_t hlw811x_disable_peak_detection(struct hlw811x *self);
 
 /**
  * @brief Enable overload detection.
@@ -438,9 +493,11 @@ hlw811x_error_t hlw811x_disable_peak_detection(void);
  *
  * @note hlw811x_enable_waveform() must be enabled to use this functionality.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
+ *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_enable_overload_detection(void);
+hlw811x_error_t hlw811x_enable_overload_detection(struct hlw811x *self);
 
 /**
  * @brief Disable overload detection.
@@ -448,9 +505,11 @@ hlw811x_error_t hlw811x_enable_overload_detection(void);
  * This function disables the overload detection feature of the HLW811X,
  * preventing the detection of overload conditions int the channel signals.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
+ *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_disable_overload_detection(void);
+hlw811x_error_t hlw811x_disable_overload_detection(struct hlw811x *self);
 
 /**
  * @brief Enable voltage drop detection.
@@ -460,9 +519,11 @@ hlw811x_error_t hlw811x_disable_overload_detection(void);
  *
  * @note hlw811x_enable_waveform() must be enabled to use this functionality.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
+ *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_enable_voltage_drop_detection(void);
+hlw811x_error_t hlw811x_enable_voltage_drop_detection(struct hlw811x *self);
 
 /**
  * @brief Disable voltage drop detection.
@@ -470,9 +531,11 @@ hlw811x_error_t hlw811x_enable_voltage_drop_detection(void);
  * This function disables the voltage drop detection feature of the HLW811X,
  * preventing the detection of voltage drops in the channel signals.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
+ *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_disable_voltage_drop_detection(void);
+hlw811x_error_t hlw811x_disable_voltage_drop_detection(struct hlw811x *self);
 
 /**
  * @brief Enable specific interrupts for the HLW811X.
@@ -480,11 +543,13 @@ hlw811x_error_t hlw811x_disable_voltage_drop_detection(void);
  * This function enables the specified interrupts for the HLW811X,
  * allowing the device to generate interrupt signals for the specified events.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[in] ints The interrupts to enable.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_enable_interrupt(hlw811x_intr_t ints);
+hlw811x_error_t hlw811x_enable_interrupt(struct hlw811x *self,
+		hlw811x_intr_t ints);
 
 /**
  * @brief Disable specific interrupts for the HLW811X.
@@ -493,11 +558,13 @@ hlw811x_error_t hlw811x_enable_interrupt(hlw811x_intr_t ints);
  * preventing the device from generating interrupt signals for the specified
  * events.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[in] ints The interrupts to disable.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_disable_interrupt(hlw811x_intr_t ints);
+hlw811x_error_t hlw811x_disable_interrupt(struct hlw811x *self,
+		hlw811x_intr_t ints);
 
 /**
  * @brief Set the interrupt mode for the HLW811X.
@@ -505,13 +572,14 @@ hlw811x_error_t hlw811x_disable_interrupt(hlw811x_intr_t ints);
  * This function sets the interrupt mode for the HLW811X, configuring how
  * the device handles and generates interrupt signals.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[in] int1 Interrupt mode for INT1 to set.
  * @param[in] int2 Interrupt mode for INT2 to set.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_set_interrupt_mode(hlw811x_intr_t int1,
-		hlw811x_intr_t int2);
+hlw811x_error_t hlw811x_set_interrupt_mode(struct hlw811x *self,
+		hlw811x_intr_t int1, hlw811x_intr_t int2);
 
 /**
  * @brief Get the current interrupt status for the HLW811X.
@@ -519,12 +587,14 @@ hlw811x_error_t hlw811x_set_interrupt_mode(hlw811x_intr_t int1,
  * This function retrieves the current interrupt status from the HLW811X,
  * indicating which interrupts are currently active.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[out] ints Pointer to the variable where the current interrupt status
  * will be stored.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_get_interrupt(hlw811x_intr_t *ints);
+hlw811x_error_t hlw811x_get_interrupt(struct hlw811x *self,
+		hlw811x_intr_t *ints);
 
 /**
  * @brief Get the current interrupt status for the HLW811X.
@@ -532,12 +602,14 @@ hlw811x_error_t hlw811x_get_interrupt(hlw811x_intr_t *ints);
  * This function retrieves the current interrupt status from the HLW811X,
  * indicating which interrupts are currently active.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[out] ints Pointer to the variable where the current interrupt status
  * will be stored.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_get_interrupt_ext(hlw811x_intr_t *ints);
+hlw811x_error_t hlw811x_get_interrupt_ext(struct hlw811x *self,
+		hlw811x_intr_t *ints);
 
 /**
  * @brief Select the active HLW811X channel.
@@ -545,11 +617,13 @@ hlw811x_error_t hlw811x_get_interrupt_ext(hlw811x_intr_t *ints);
  * This function selects the specified HLW811X channel as the active channel for
  * subsequent operations.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[in] channel The HLW811X channel to select.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_select_channel(hlw811x_channel_t channel);
+hlw811x_error_t hlw811x_select_channel(struct hlw811x *self,
+		hlw811x_channel_t channel);
 
 /**
  * @brief Read the current active HLW811X channel.
@@ -557,12 +631,14 @@ hlw811x_error_t hlw811x_select_channel(hlw811x_channel_t channel);
  * This function reads the current active channel of the HLW811X and stores it
  * in the provided channel variable.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[out] channel Pointer to the variable where the current active channel
  * will be stored.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_read_current_channel(hlw811x_channel_t *channel);
+hlw811x_error_t hlw811x_read_current_channel(struct hlw811x *self,
+		hlw811x_channel_t *channel);
 
 /**
  * @brief Read the calibration coefficients from the HLW811X.
@@ -570,12 +646,14 @@ hlw811x_error_t hlw811x_read_current_channel(hlw811x_channel_t *channel);
  * This function reads the calibration coefficients from the HLW811X and stores
  * them in the provided hlw811x_coeff structure.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[out] coeff Pointer to the structure where the calibration coefficients
  * will be stored.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_read_coeff(struct hlw811x_coeff *coeff);
+hlw811x_error_t hlw811x_read_coeff(struct hlw811x *self,
+		struct hlw811x_coeff *coeff);
 
 /**
  * @brief Set the resistor ratio for the HLW811X.
@@ -583,20 +661,24 @@ hlw811x_error_t hlw811x_read_coeff(struct hlw811x_coeff *coeff);
  * This function sets the resistor ratio for the HLW811X, which is used for
  * internal calculations related to voltage and current measurements.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param ratio[in] Pointer to the structure containing the resistor ratio
  * values.
  */
-void hlw811x_set_resistor_ratio(const struct hlw811x_resistor_ratio *ratio);
+void hlw811x_set_resistor_ratio(struct hlw811x *self,
+		const struct hlw811x_resistor_ratio *ratio);
 
 /**
  * @brief Get the resistor ratio for the HLW811X.
  *
  * This function retrieves the current resistor ratio settings from the HLW811X.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param ratio[out] Pointer to the structure where the resistor ratio values
  * will be stored.
  */
-void hlw811x_get_resistor_ratio(struct hlw811x_resistor_ratio *ratio);
+void hlw811x_get_resistor_ratio(struct hlw811x *self,
+		struct hlw811x_resistor_ratio *ratio);
 
 /**
  * @brief Set the programmable gain amplifier (PGA) settings for the HLW811X.
@@ -604,23 +686,26 @@ void hlw811x_get_resistor_ratio(struct hlw811x_resistor_ratio *ratio);
  * This function sets the PGA settings for the HLW811X, which are used to adjust
  * the gain for voltage and current measurements.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[in] pga Pointer to the structure containing the PGA settings.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_set_pga(const struct hlw811x_pga *pga);
+hlw811x_error_t hlw811x_set_pga(struct hlw811x *self,
+		const struct hlw811x_pga *pga);
 
 /**
  * @brief Get the programmable gain amplifier (PGA) settings for the HLW811X.
  *
  * This function retrieves the current PGA settings from the HLW811X.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param pga[out] Pointer to the structure where the PGA settings will be
  * stored.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_get_pga(struct hlw811x_pga *pga);
+hlw811x_error_t hlw811x_get_pga(struct hlw811x *self, struct hlw811x_pga *pga);
 
 /**
  * @brief Set the active power calculation mode for the HLW811X.
@@ -628,12 +713,13 @@ hlw811x_error_t hlw811x_get_pga(struct hlw811x_pga *pga);
  * This function sets the active power calculation mode for the HLW811X,
  * which determines how the active power is calculated.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[in] mode The active power calculation mode to set.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_set_active_power_calc_mode(hlw811x_active_power_mode_t
-		mode);
+hlw811x_error_t hlw811x_set_active_power_calc_mode(struct hlw811x *self,
+		hlw811x_active_power_mode_t mode);
 
 /**
  * @brief Get the active power calculation mode for the HLW811X.
@@ -641,13 +727,14 @@ hlw811x_error_t hlw811x_set_active_power_calc_mode(hlw811x_active_power_mode_t
  * This function retrieves the current active power calculation mode from the
  * HLW811X.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[out] mode Pointer to the variable where the current active power
  * calculation mode will be stored.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_get_active_power_calc_mode(hlw811x_active_power_mode_t
-		*mode);
+hlw811x_error_t hlw811x_get_active_power_calc_mode(struct hlw811x *self,
+		hlw811x_active_power_mode_t *mode);
 
 /**
  * @brief Set the RMS calculation mode for the HLW811X.
@@ -655,11 +742,13 @@ hlw811x_error_t hlw811x_get_active_power_calc_mode(hlw811x_active_power_mode_t
  * This function sets the RMS (Root Mean Square) calculation mode for the
  * HLW811X, which determines how the RMS values are calculated.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[in] mode The RMS calculation mode to set.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_set_rms_calc_mode(hlw811x_rms_mode_t mode);
+hlw811x_error_t hlw811x_set_rms_calc_mode(struct hlw811x *self,
+		hlw811x_rms_mode_t mode);
 
 /**
  * @brief Get the RMS calculation mode for the HLW811X.
@@ -667,12 +756,14 @@ hlw811x_error_t hlw811x_set_rms_calc_mode(hlw811x_rms_mode_t mode);
  * This function retrieves the current RMS (Root Mean Square) calculation mode
  * from the HLW811X.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[out] mode Pointer to the variable where the current RMS calculation
  * mode will be stored.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_get_rms_calc_mode(hlw811x_rms_mode_t *mode);
+hlw811x_error_t hlw811x_get_rms_calc_mode(struct hlw811x *self,
+		hlw811x_rms_mode_t *mode);
 
 /**
  * @brief Set the data update frequency for the HLW811X.
@@ -680,25 +771,27 @@ hlw811x_error_t hlw811x_get_rms_calc_mode(hlw811x_rms_mode_t *mode);
  * This function sets the data update frequency for the HLW811X, which determines
  * how often the data is updated.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[in] freq The data update frequency to set.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_set_data_update_frequency(hlw811x_data_update_freq_t
-		freq);
+hlw811x_error_t hlw811x_set_data_update_frequency(struct hlw811x *self,
+		hlw811x_data_update_freq_t freq);
 
 /**
  * @brief Get the data update frequency for the HLW811X.
  *
  * This function retrieves the current data update frequency from the HLW811X.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[out] freq Pointer to the variable where the current data update
  * frequency will be stored.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_get_data_update_frequency(hlw811x_data_update_freq_t
-		*freq);
+hlw811x_error_t hlw811x_get_data_update_frequency(struct hlw811x *self,
+		hlw811x_data_update_freq_t *freq);
 
 /**
  * @brief Set the mode for HLW811X channel B.
@@ -706,23 +799,27 @@ hlw811x_error_t hlw811x_get_data_update_frequency(hlw811x_data_update_freq_t
  * This function sets the mode for HLW811X channel B, which determines the
  * operational behavior of channel B.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[in] mode The mode to set for channel B.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_set_channel_b_mode(hlw811x_channel_b_mode_t mode);
+hlw811x_error_t hlw811x_set_channel_b_mode(struct hlw811x *self,
+		hlw811x_channel_b_mode_t mode);
 
 /**
  * @brief Get the mode for HLW811X channel B.
  *
  * This function retrieves the current mode of HLW811X channel B.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[out] mode Pointer to the variable where the current mode of channel B
  * will be stored.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_get_channel_b_mode(hlw811x_channel_b_mode_t *mode);
+hlw811x_error_t hlw811x_get_channel_b_mode(struct hlw811x *self,
+		hlw811x_channel_b_mode_t *mode);
 
 /**
  * @brief Set the zero-crossing detection mode for the HLW811X.
@@ -730,11 +827,13 @@ hlw811x_error_t hlw811x_get_channel_b_mode(hlw811x_channel_b_mode_t *mode);
  * This function sets the zero-crossing detection mode for the HLW811X,
  * which determines how zero-crossing points in the waveform are detected.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[in] mode The zero-crossing detection mode to set.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_set_zerocrossing_mode(hlw811x_zerocrossing_mode_t mode);
+hlw811x_error_t hlw811x_set_zerocrossing_mode(struct hlw811x *self,
+		hlw811x_zerocrossing_mode_t mode);
 
 /**
  * @brief Get the zero-crossing detection mode for the HLW811X.
@@ -742,13 +841,14 @@ hlw811x_error_t hlw811x_set_zerocrossing_mode(hlw811x_zerocrossing_mode_t mode);
  * This function retrieves the current zero-crossing detection mode from the
  * HLW811X.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[out] mode Pointer to the variable where the current zero-crossing
  * detection mode will be stored.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_get_zerocrossing_mode(hlw811x_zerocrossing_mode_t
-		*mode);
+hlw811x_error_t hlw811x_get_zerocrossing_mode(struct hlw811x *self,
+		hlw811x_zerocrossing_mode_t *mode);
 
 /**
  * @brief Get the RMS value for a specified HLW811X channel.
@@ -756,13 +856,15 @@ hlw811x_error_t hlw811x_get_zerocrossing_mode(hlw811x_zerocrossing_mode_t
  * This function retrieves the RMS (Root Mean Square) value for the specified
  * HLW811X channel and stores it in the provided milliunit variable.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[in] channel The HLW811X channel to get the RMS value for.
  * @param[out] milliunit Pointer to the variable where the RMS value (in
  * milliunits) will be stored.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_get_rms(hlw811x_channel_t channel, int32_t *milliunit);
+hlw811x_error_t hlw811x_get_rms(struct hlw811x *self,
+		hlw811x_channel_t channel, int32_t *milliunit);
 
 /**
  * @brief Get the power value for a specified HLW811X channel.
@@ -770,13 +872,15 @@ hlw811x_error_t hlw811x_get_rms(hlw811x_channel_t channel, int32_t *milliunit);
  * This function retrieves the power value for the specified HLW811X channel
  * and stores it in the provided milliwatt variable.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[in] channel The HLW811X channel to get the power value for.
  * @param[out] milliwatt Pointer to the variable where the power value (in
  * milliwatts) will be stored.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_get_power(hlw811x_channel_t channel, int32_t *milliwatt);
+hlw811x_error_t hlw811x_get_power(struct hlw811x *self,
+		hlw811x_channel_t channel, int32_t *milliwatt);
 
 /**
  * @brief Get the energy value for a specified HLW811X channel.
@@ -784,13 +888,15 @@ hlw811x_error_t hlw811x_get_power(hlw811x_channel_t channel, int32_t *milliwatt)
  * This function retrieves the energy value for the specified HLW811X channel
  * and stores it in the provided Wh variable.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[in] channel The HLW811X channel to get the energy value for.
  * @param[out] Wh Pointer to the variable where the energy value (in watt-hours)
  * will be stored.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_get_energy(hlw811x_channel_t channel, int32_t *Wh);
+hlw811x_error_t hlw811x_get_energy(struct hlw811x *self,
+		hlw811x_channel_t channel, int32_t *Wh);
 
 /**
  * @brief Get the frequency of the HLW811X.
@@ -803,12 +909,13 @@ hlw811x_error_t hlw811x_get_energy(hlw811x_channel_t channel, int32_t *Wh);
  * @note hlw811x_enable_zerocrossing() must be enabled to use this
  * functionality.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[out] centihertz Pointer to the variable where the frequency (in
  * centihertz) will be stored.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_get_frequency(int32_t *centihertz);
+hlw811x_error_t hlw811x_get_frequency(struct hlw811x *self, int32_t *centihertz);
 
 /**
  * @brief Get the power factor of the HLW811X.
@@ -816,12 +923,13 @@ hlw811x_error_t hlw811x_get_frequency(int32_t *centihertz);
  * This function retrieves the power factor of the HLW811X and stores it in the
  * provided centiunit variable.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[out] centiunit Pointer to the variable where the power factor (in
  * centiunits) will be stored.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_get_power_factor(int32_t *centiunit);
+hlw811x_error_t hlw811x_get_power_factor(struct hlw811x *self, int32_t *centi);
 
 /**
  * @brief Get the phase angle of the HLW811X.
@@ -829,14 +937,15 @@ hlw811x_error_t hlw811x_get_power_factor(int32_t *centiunit);
  * This function retrieves the phase angle of the HLW811X and stores it in the
  * provided centidegree variable.
  *
+ * @param[in] self A pointer to the HLW811X device structure.
  * @param[out] centidegree Pointer to the variable where the phase angle (in
  * centidegrees) will be stored.
  * @param[int] freq The line frequency to use for the phase angle calculation.
  *
  * @return hlw811x_error_t Error code indicating the result of the operation.
  */
-hlw811x_error_t hlw811x_get_phase_angle(int32_t *centidegree,
-		hlw811x_line_freq_t freq);
+hlw811x_error_t hlw811x_get_phase_angle(struct hlw811x *self,
+		int32_t *centidegree, hlw811x_line_freq_t freq);
 
 #if defined(__cplusplus)
 }

--- a/hlw811x_overrides.h
+++ b/hlw811x_overrides.h
@@ -21,10 +21,12 @@ extern "C" {
  *
  * @param[in] data Pointer to the data to be written.
  * @param[in] datalen Length of the data to be written.
+ * @param[in] ctx Pointer to the context or additional parameters required for
+ *            the write operation.
  *
  * @return int Returns 0 on success, or a negative error code on failure.
  */
-int hlw811x_ll_write(const uint8_t *data, size_t datalen);
+int hlw811x_ll_write(const uint8_t *data, size_t datalen, void *ctx);
 
 /**
  * @brief Reads data from the HLW811X device at a low level.
@@ -32,12 +34,14 @@ int hlw811x_ll_write(const uint8_t *data, size_t datalen);
  * This function reads data from the HLW811X device into the specified buffer.
  *
  * @param[out] buf Pointer to the buffer where the read data will be stored.
- * @param[int] bufsize Size of the buffer.
+ * @param[in] bufsize Size of the buffer.
+ * @param[in] ctx Pointer to the context or additional parameters required for
+ *            the read operation.
  *
  * @return int Returns the number of bytes read on success, or a negative error
  *             code on failure.
  */
-int hlw811x_ll_read(uint8_t *buf, size_t bufsize);
+int hlw811x_ll_read(uint8_t *buf, size_t bufsize, void *ctx);
 
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
This pull request includes significant changes to the HLW811X device API, focusing on improving clarity and functionality. The key changes involve the addition of context parameters to various functions and the introduction of new functions for creating and destroying device instances.

### API Enhancements:

* **Initialization and Destruction:**
  * Added `hlw811x_create` function to create and initialize an HLW811X device instance, returning a pointer to the created instance.
  * Added `hlw811x_destroy` function to destroy an HLW811X device instance and free allocated resources.

* **Function Parameter Updates:**
  * Updated multiple functions to include a `self` parameter, which is a pointer to the HLW811X device structure. This change affects functions such as `hlw811x_reset`, `hlw811x_write_reg`, `hlw811x_read_reg`, and several others. [[1]](diffhunk://#diff-21dcb5946cfc8c9963a6db1d7d47abcadd5f451ff3d9e8a1ef0f5bb95ca04f04R175-R290) [[2]](diffhunk://#diff-21dcb5946cfc8c9963a6db1d7d47abcadd5f451ff3d9e8a1ef0f5bb95ca04f04R300-R340) [[3]](diffhunk://#diff-21dcb5946cfc8c9963a6db1d7d47abcadd5f451ff3d9e8a1ef0f5bb95ca04f04R349-R397) [[4]](diffhunk://#diff-21dcb5946cfc8c9963a6db1d7d47abcadd5f451ff3d9e8a1ef0f5bb95ca04f04R419-R435) [[5]](diffhunk://#diff-21dcb5946cfc8c9963a6db1d7d47abcadd5f451ff3d9e8a1ef0f5bb95ca04f04L399-R460) [[6]](diffhunk://#diff-21dcb5946cfc8c9963a6db1d7d47abcadd5f451ff3d9e8a1ef0f5bb95ca04f04R470-R486) [[7]](diffhunk://#diff-21dcb5946cfc8c9963a6db1d7d47abcadd5f451ff3d9e8a1ef0f5bb95ca04f04R496-R512) [[8]](diffhunk://#diff-21dcb5946cfc8c9963a6db1d7d47abcadd5f451ff3d9e8a1ef0f5bb95ca04f04R522-R552)

These changes enhance the flexibility and robustness of the HLW811X device API, making it easier to manage device instances and improving the overall clarity of the function signatures.