### PR TITLE
feat(hlw811x): add calibration support

### DIFF
--- a/hlw811x.c
+++ b/hlw811x.c
@@ -1512,6 +1512,42 @@ hlw811x_error_t hlw811x_disable_channel(struct hlw811x *self,
 	return err;
 }
 
+hlw811x_error_t hlw811x_apply_calibration(struct hlw811x *self,
+		const struct hlw811x_calibration *cal)
+{
+#define swap16(x) (uint16_t)(((x) >> 8) | ((x) << 8))
+	uint16_t t;
+	uint8_t *p = (uint8_t *)&t;
+	hlw811x_error_t err = HLW811X_ERROR_NONE;
+
+	*p = swap16(cal->hfconst);
+	err |= write_reg(self, HLW811X_REG_PULSE_FREQ, p, sizeof(*p));
+	*p = swap16(cal->pa_gain);
+	err |= write_reg(self, HLW811X_REG_POWER_GAIN_A, p, sizeof(*p));
+	*p = swap16(cal->pb_gain);
+	err |= write_reg(self, HLW811X_REG_POWER_GAIN_B, p, sizeof(*p));
+	*p = swap16(cal->phase_a);
+	err |= write_reg(self, HLW811X_REG_PHASE_A, p, 1);
+	*p = swap16(cal->phase_a);
+	err |= write_reg(self, HLW811X_REG_PHASE_B, p, 1);
+	*p = swap16(cal->paos);
+	err |= write_reg(self, HLW811X_REG_ACTIVE_POWER_OFFSET_A, p, sizeof(*p));
+	*p = swap16(cal->pbos);
+	err |= write_reg(self, HLW811X_REG_ACTIVE_POWER_OFFSET_B, p, sizeof(*p));
+	*p = swap16(cal->rms_iaos);
+	err |= write_reg(self, HLW811X_REG_RMS_OFFSET_IA, p, sizeof(*p));
+	*p = swap16(cal->rms_ibos);
+	err |= write_reg(self, HLW811X_REG_RMS_OFFSET_IB, p, sizeof(*p));
+	*p = swap16(cal->ib_gain);
+	err |= write_reg(self, HLW811X_REG_GAIN_IB, p, sizeof(*p));
+	*p = swap16(cal->ps_gain);
+	err |= write_reg(self, HLW811X_REG_APPARENT_POWER_GAIN, p, sizeof(*p));
+	*p = swap16(cal->psos);
+	err |= write_reg(self, HLW811X_REG_VISUAL_POWER_OFFSET, p, sizeof(*p));
+
+	return err;
+}
+
 hlw811x_error_t hlw811x_reset(struct hlw811x *self)
 {
 	HLW811X_INFO("Resetting HLW811X chip");

--- a/hlw811x.c
+++ b/hlw811x.c
@@ -1516,34 +1516,34 @@ hlw811x_error_t hlw811x_apply_calibration(struct hlw811x *self,
 		const struct hlw811x_calibration *cal)
 {
 #define swap16(x) (uint16_t)(((x) >> 8) | ((x) << 8))
-	uint16_t t;
-	uint8_t *p = (uint8_t *)&t;
+	uint16_t tmp;
+	uint8_t *p = (uint8_t *)&tmp;
 	hlw811x_error_t err = HLW811X_ERROR_NONE;
 
-	*p = swap16(cal->hfconst);
-	err |= write_reg(self, HLW811X_REG_PULSE_FREQ, p, sizeof(*p));
-	*p = swap16(cal->pa_gain);
-	err |= write_reg(self, HLW811X_REG_POWER_GAIN_A, p, sizeof(*p));
-	*p = swap16(cal->pb_gain);
-	err |= write_reg(self, HLW811X_REG_POWER_GAIN_B, p, sizeof(*p));
-	*p = swap16(cal->phase_a);
-	err |= write_reg(self, HLW811X_REG_PHASE_A, p, 1);
-	*p = swap16(cal->phase_a);
-	err |= write_reg(self, HLW811X_REG_PHASE_B, p, 1);
-	*p = swap16(cal->paos);
-	err |= write_reg(self, HLW811X_REG_ACTIVE_POWER_OFFSET_A, p, sizeof(*p));
-	*p = swap16(cal->pbos);
-	err |= write_reg(self, HLW811X_REG_ACTIVE_POWER_OFFSET_B, p, sizeof(*p));
-	*p = swap16(cal->rms_iaos);
-	err |= write_reg(self, HLW811X_REG_RMS_OFFSET_IA, p, sizeof(*p));
-	*p = swap16(cal->rms_ibos);
-	err |= write_reg(self, HLW811X_REG_RMS_OFFSET_IB, p, sizeof(*p));
-	*p = swap16(cal->ib_gain);
-	err |= write_reg(self, HLW811X_REG_GAIN_IB, p, sizeof(*p));
-	*p = swap16(cal->ps_gain);
-	err |= write_reg(self, HLW811X_REG_APPARENT_POWER_GAIN, p, sizeof(*p));
-	*p = swap16(cal->psos);
-	err |= write_reg(self, HLW811X_REG_VISUAL_POWER_OFFSET, p, sizeof(*p));
+	tmp = swap16(cal->hfconst);
+	err |= write_reg(self, HLW811X_REG_PULSE_FREQ, p, sizeof(tmp));
+	tmp = swap16(cal->pa_gain);
+	err |= write_reg(self, HLW811X_REG_POWER_GAIN_A, p, sizeof(tmp));
+	tmp = swap16(cal->pb_gain);
+	err |= write_reg(self, HLW811X_REG_POWER_GAIN_B, p, sizeof(tmp));
+	*p = cal->phase_a;
+	err |= write_reg(self, HLW811X_REG_PHASE_A, p, sizeof(*p));
+	*p = cal->phase_b;
+	err |= write_reg(self, HLW811X_REG_PHASE_B, p, sizeof(*p));
+	tmp = swap16(cal->paos);
+	err |= write_reg(self, HLW811X_REG_ACTIVE_POWER_OFFSET_A, p, sizeof(tmp));
+	tmp = swap16(cal->pbos);
+	err |= write_reg(self, HLW811X_REG_ACTIVE_POWER_OFFSET_B, p, sizeof(tmp));
+	tmp = swap16(cal->rms_iaos);
+	err |= write_reg(self, HLW811X_REG_RMS_OFFSET_IA, p, sizeof(tmp));
+	tmp = swap16(cal->rms_ibos);
+	err |= write_reg(self, HLW811X_REG_RMS_OFFSET_IB, p, sizeof(tmp));
+	tmp = swap16(cal->ib_gain);
+	err |= write_reg(self, HLW811X_REG_GAIN_IB, p, sizeof(tmp));
+	tmp = swap16(cal->ps_gain);
+	err |= write_reg(self, HLW811X_REG_APPARENT_POWER_GAIN, p, sizeof(tmp));
+	tmp = swap16(cal->psos);
+	err |= write_reg(self, HLW811X_REG_VISUAL_POWER_OFFSET, p, sizeof(tmp));
 
 	return err;
 }

--- a/hlw811x.c
+++ b/hlw811x.c
@@ -1512,6 +1512,40 @@ hlw811x_error_t hlw811x_disable_channel(struct hlw811x *self,
 	return err;
 }
 
+hlw811x_error_t hlw811x_get_calibration(struct hlw811x *self,
+		struct hlw811x_calibration *cal)
+{
+	uint8_t buf[2];
+	hlw811x_error_t err;
+
+	err = read_reg(self, HLW811X_REG_PULSE_FREQ, buf, sizeof(buf));
+	cal->hfconst = (uint16_t)((buf[0] << 8) | buf[1]);
+	err |= read_reg(self, HLW811X_REG_POWER_GAIN_A, buf, sizeof(buf));
+	cal->pa_gain = (uint16_t)((buf[0] << 8) | buf[1]);
+	err |= read_reg(self, HLW811X_REG_POWER_GAIN_B, buf, sizeof(buf));
+	cal->pb_gain = (uint16_t)((buf[0] << 8) | buf[1]);
+	err |= read_reg(self, HLW811X_REG_PHASE_A, buf, 1);
+	cal->phase_a = buf[0];
+	err |= read_reg(self, HLW811X_REG_PHASE_B, buf, 1);
+	cal->phase_b = buf[0];
+	err |= read_reg(self, HLW811X_REG_ACTIVE_POWER_OFFSET_A, buf, sizeof(buf));
+	cal->paos = (uint16_t)((buf[0] << 8) | buf[1]);
+	err |= read_reg(self, HLW811X_REG_ACTIVE_POWER_OFFSET_B, buf, sizeof(buf));
+	cal->pbos = (uint16_t)((buf[0] << 8) | buf[1]);
+	err |= read_reg(self, HLW811X_REG_RMS_OFFSET_IA, buf, sizeof(buf));
+	cal->rms_iaos = (uint16_t)((buf[0] << 8) | buf[1]);
+	err |= read_reg(self, HLW811X_REG_RMS_OFFSET_IB, buf, sizeof(buf));
+	cal->rms_ibos = (uint16_t)((buf[0] << 8) | buf[1]);
+	err |= read_reg(self, HLW811X_REG_GAIN_IB, buf, sizeof(buf));
+	cal->ib_gain = (uint16_t)((buf[0] << 8) | buf[1]);
+	err |= read_reg(self, HLW811X_REG_APPARENT_POWER_GAIN, buf, sizeof(buf));
+	cal->ps_gain = (uint16_t)((buf[0] << 8) | buf[1]);
+	err |= read_reg(self, HLW811X_REG_VISUAL_POWER_OFFSET, buf, sizeof(buf));
+	cal->psos = (uint16_t)((buf[0] << 8) | buf[1]);
+
+	return err;
+}
+
 hlw811x_error_t hlw811x_apply_calibration(struct hlw811x *self,
 		const struct hlw811x_calibration *cal)
 {

--- a/hlw811x.h
+++ b/hlw811x.h
@@ -136,6 +136,21 @@ struct hlw811x_pga {
 	hlw811x_pga_gain_t U;
 };
 
+struct hlw811x_calibration {
+	uint16_t hfconst; /* pulse frequency constant */
+	uint16_t pa_gain; /* active power gain for channel A */
+	uint16_t pb_gain; /* active power gain for channel B */
+	uint8_t phase_a; /* phase angle gain for channel A */
+	uint8_t phase_b; /* phase angle gain for channel B */
+	uint16_t paos; /* active power offset for channel A */
+	uint16_t pbos; /* active power offset for channel B */
+	uint16_t rms_iaos; /* RMS offset for current channel A */
+	uint16_t rms_ibos; /* RMS offset for current channel B */
+	uint16_t ib_gain; /* gain for current channel B */
+	uint16_t ps_gain; /* gain for voltage channel */
+	uint16_t psos; /* apparent power offset */
+};
+
 /**
  * @brief Create and initialize an HLW811X device instance.
  *
@@ -178,6 +193,21 @@ void hlw811x_destroy(struct hlw811x *hlw811x);
  *                         failure of the reset operation.
  */
 hlw811x_error_t hlw811x_reset(struct hlw811x *self);
+
+/**
+ * @brief Apply calibration parameters to the HLW811X device.
+ *
+ * This function configures the HLW811X device with the provided calibration
+ * parameters to ensure accurate measurements.
+ *
+ * @param[in] self Pointer to the HLW811X device instance.
+ * @param[in] cal Pointer to the calibration parameters to be applied.
+ *
+ * @return hlw811x_error_t Error code indicating the success or failure of the
+ *         operation.
+ */
+hlw811x_error_t hlw811x_apply_calibration(struct hlw811x *self,
+		const struct hlw811x_calibration *cal);
 
 /**
  * @brief Write data to a specified HLW811X register.

--- a/hlw811x.h
+++ b/hlw811x.h
@@ -195,21 +195,6 @@ void hlw811x_destroy(struct hlw811x *hlw811x);
 hlw811x_error_t hlw811x_reset(struct hlw811x *self);
 
 /**
- * @brief Apply calibration parameters to the HLW811X device.
- *
- * This function configures the HLW811X device with the provided calibration
- * parameters to ensure accurate measurements.
- *
- * @param[in] self Pointer to the HLW811X device instance.
- * @param[in] cal Pointer to the calibration parameters to be applied.
- *
- * @return hlw811x_error_t Error code indicating the success or failure of the
- *         operation.
- */
-hlw811x_error_t hlw811x_apply_calibration(struct hlw811x *self,
-		const struct hlw811x_calibration *cal);
-
-/**
  * @brief Write data to a specified HLW811X register.
  *
  * This function writes the specified data to the HLW811X register at the given
@@ -976,6 +961,122 @@ hlw811x_error_t hlw811x_get_power_factor(struct hlw811x *self, int32_t *centi);
  */
 hlw811x_error_t hlw811x_get_phase_angle(struct hlw811x *self,
 		int32_t *centidegree, hlw811x_line_freq_t freq);
+
+/**
+ * @brief Apply calibration parameters to the HLW811X device.
+ *
+ * This function configures the HLW811X device with the provided calibration
+ * parameters to ensure accurate measurements.
+ *
+ * @param[in] self Pointer to the HLW811X device instance.
+ * @param[in] cal Pointer to the calibration parameters to be applied.
+ *
+ * @return hlw811x_error_t Error code indicating the success or failure of the
+ *         operation.
+ */
+hlw811x_error_t hlw811x_apply_calibration(struct hlw811x *self,
+		const struct hlw811x_calibration *cal);
+
+/**
+ * @brief Retrieve the calibration data for the HLW811X instance.
+ *
+ * This function retrieves the calibration data, including various gain
+ * and offset values, for the specified HLW811X instance.
+ *
+ * @param[in] self Pointer to the hlw811x instance.
+ * @param[out] cal Pointer to a structure where the calibration data will be stored.
+ *
+ * @return hlw811x_error_t Error code indicating success or failure.
+ */
+hlw811x_error_t hlw811x_get_calibration(struct hlw811x *self,
+		struct hlw811x_calibration *cal);
+
+/**
+ * @brief Calculate the current gain for channel B.
+ *
+ * This function calculates the current gain for channel B by determining
+ * the ratio of the RMS current values between channel A and channel B.
+ *
+ * @param[in] self Pointer to the hlw811x instance.
+ * @param[out] ib_gain Pointer to store the calculated current gain for channel B.
+ *
+ * @return hlw811x_error_t Error code indicating success or failure.
+ */
+hlw811x_error_t hlw811x_calc_current_gain_b(struct hlw811x *self,
+		uint16_t *ib_gain);
+
+/**
+ * @brief Calculate the active power gain for the specified channel.
+ *
+ * This function is used when PF=1 and Ib=100%.
+ *
+ * @param[in] self Pointer to the hlw811x instance.
+ * @param[in] channel The channel (A or B) for which the gain is calculated.
+ * @param[in] error_pct The error percentage to be considered.
+ * @param[out] px_gain Pointer to store the calculated active power gain.
+ *
+ * @return hlw811x_error_t Error code indicating success or failure.
+ */
+hlw811x_error_t hlw811x_calc_active_power_gain(struct hlw811x *self,
+		const hlw811x_channel_t channel, const int8_t error_pct,
+		uint16_t *px_gain);
+
+/**
+ * @brief Calculate the active power offset for the specified channel.
+ *
+ * This function is used when PF=1 and Ib=5%.
+ *
+ * @param[in] self Pointer to the hlw811x instance.
+ * @param[in] channel The channel (A or B) for which the offset is calculated.
+ * @param[in] error_pct The error percentage to be considered.
+ * @param[out] px_offset Pointer to store the calculated active power offset.
+ *
+ * @return hlw811x_error_t Error code indicating success or failure.
+ */
+hlw811x_error_t hlw811x_calc_active_power_offset(struct hlw811x *self,
+		const hlw811x_channel_t channel, const int8_t error_pct,
+		uint16_t *px_offset);
+
+/**
+ * @brief Calculate the RMS offset for the specified channel.
+ *
+ * This function is used when PF=1 and Ib=0%.
+ *
+ * @param[in] self Pointer to the hlw811x instance.
+ * @param[in] channel The channel (A or B) for which the RMS offset is calculated.
+ * @param[out] rms_offset Pointer to store the calculated RMS offset.
+ *
+ * @return hlw811x_error_t Error code indicating success or failure.
+ */
+hlw811x_error_t hlw811x_calc_rms_offset(struct hlw811x *self,
+		const hlw811x_channel_t channel, uint16_t *rms_offset);
+
+/**
+ * @brief Calculate the apparent power gain.
+ *
+ * This function is used when PF=1 and Ib=100%.
+ *
+ * @param[in] self Pointer to the hlw811x instance.
+ * @param[out] ps_gain Pointer to store the calculated apparent power gain.
+ *
+ * @return hlw811x_error_t Error code indicating success or failure.
+ */
+hlw811x_error_t hlw811x_calc_apparent_power_gain(struct hlw811x *self,
+		uint16_t *ps_gain);
+
+/**
+ * @brief Calculate the apparent power offset.
+ *
+ * This function is used when PF=1 and Ib=0%.
+ *
+ * @param[in] self Pointer to the hlw811x instance.
+ * @param[out] ps_offset Pointer to store the calculated apparent power offset.
+ *
+ * @return hlw811x_error_t Error code indicating success or failure.
+ */
+hlw811x_error_t hlw811x_calc_apparent_power_offset(struct hlw811x *self,
+		uint16_t *ps_offset);
+
 
 #if defined(__cplusplus)
 }

--- a/hlw811x.h
+++ b/hlw811x.h
@@ -997,8 +997,12 @@ hlw811x_error_t hlw811x_get_calibration(struct hlw811x *self,
  * This function calculates the current gain for channel B by determining
  * the ratio of the RMS current values between channel A and channel B.
  *
+ * @note The ib_gain value must be written to the IBGain register to take
+ *       effect.
+ *
  * @param[in] self Pointer to the hlw811x instance.
- * @param[out] ib_gain Pointer to store the calculated current gain for channel B.
+ * @param[out] ib_gain Pointer to store the calculated current gain for
+ *             channel B.
  *
  * @return hlw811x_error_t Error code indicating success or failure.
  */
@@ -1010,21 +1014,25 @@ hlw811x_error_t hlw811x_calc_current_gain_b(struct hlw811x *self,
  *
  * This function is used when PF=1 and Ib=100%.
  *
+ * @note The calculated px_gain value must be written to the PxGain register
+ *       to take effect.
+ *
  * @param[in] self Pointer to the hlw811x instance.
- * @param[in] channel The channel (A or B) for which the gain is calculated.
  * @param[in] error_pct The error percentage to be considered.
  * @param[out] px_gain Pointer to store the calculated active power gain.
  *
  * @return hlw811x_error_t Error code indicating success or failure.
  */
 hlw811x_error_t hlw811x_calc_active_power_gain(struct hlw811x *self,
-		const hlw811x_channel_t channel, const int8_t error_pct,
-		uint16_t *px_gain);
+		const float error_pct, uint16_t *px_gain);
 
 /**
  * @brief Calculate the active power offset for the specified channel.
  *
  * This function is used when PF=1 and Ib=5%.
+ *
+ * @note The calculated px_offset value must be written to the PxOS register
+ *       to take effect.
  *
  * @param[in] self Pointer to the hlw811x instance.
  * @param[in] channel The channel (A or B) for which the offset is calculated.
@@ -1034,13 +1042,16 @@ hlw811x_error_t hlw811x_calc_active_power_gain(struct hlw811x *self,
  * @return hlw811x_error_t Error code indicating success or failure.
  */
 hlw811x_error_t hlw811x_calc_active_power_offset(struct hlw811x *self,
-		const hlw811x_channel_t channel, const int8_t error_pct,
+		const hlw811x_channel_t channel, const float error_pct,
 		uint16_t *px_offset);
 
 /**
  * @brief Calculate the RMS offset for the specified channel.
  *
  * This function is used when PF=1 and Ib=0%.
+ *
+ * @note The calculated rms_offset value must be written to the RmsIxOS
+ *       register to take effect.
  *
  * @param[in] self Pointer to the hlw811x instance.
  * @param[in] channel The channel (A or B) for which the RMS offset is calculated.
@@ -1056,6 +1067,9 @@ hlw811x_error_t hlw811x_calc_rms_offset(struct hlw811x *self,
  *
  * This function is used when PF=1 and Ib=100%.
  *
+ * @note The calculated ps_gain value must be written to the PSGain register
+ *       to take effect.
+ *
  * @param[in] self Pointer to the hlw811x instance.
  * @param[out] ps_gain Pointer to store the calculated apparent power gain.
  *
@@ -1068,6 +1082,9 @@ hlw811x_error_t hlw811x_calc_apparent_power_gain(struct hlw811x *self,
  * @brief Calculate the apparent power offset.
  *
  * This function is used when PF=1 and Ib=0%.
+ *
+ * @note The calculated ps_offset value must be written to the PSOS register
+ *       to take effect.
  *
  * @param[in] self Pointer to the hlw811x instance.
  * @param[out] ps_offset Pointer to store the calculated apparent power offset.

--- a/tests/src/hlw811x_test.cpp
+++ b/tests/src/hlw811x_test.cpp
@@ -301,3 +301,41 @@ TEST(HLW811x, apply_calibration_ShouldApplyCalibration) {
 	expect_write("\xA5\x92\x77\x77\xDA", 5);
 	LONGS_EQUAL(HLW811X_ERROR_NONE, hlw811x_apply_calibration(hlw811x, &expected));
 }
+
+TEST(HLW811x, calc_active_power_gain_ShouldReturnCalculatedGain) {
+	uint16_t gain;
+	float err = 1.0918f; // Example error percentage
+	LONGS_EQUAL(HLW811X_ERROR_NONE, hlw811x_calc_active_power_gain(hlw811x, err, &gain));
+	LONGS_EQUAL(0xFE9F, gain);
+}
+
+TEST(HLW811x, calc_active_power_offset_ShouldReturnCalculatedOffset) {
+	uint16_t offset;
+	float error_pct = -0.2553f; // Example error percentage
+	expect_read("\xA5\x2C", "\x00\x0F\x5A\xB7\x0E", 5);
+	LONGS_EQUAL(HLW811X_ERROR_NONE, hlw811x_calc_active_power_offset(hlw811x, HLW811X_CHANNEL_A, error_pct, &offset));
+	LONGS_EQUAL(0xa08, offset);
+}
+
+TEST(HLW811x, calc_rms_offset_ShouldReturnCalculatedOffset) {
+	uint16_t offset;
+	expect_read("\xA5\x24", "\x00\x01\xc3\x72", 4);
+	LONGS_EQUAL(HLW811X_ERROR_NONE, hlw811x_calc_rms_offset(hlw811x, HLW811X_CHANNEL_A, &offset));
+	LONGS_EQUAL(0xFE3D, offset);
+}
+
+TEST(HLW811x, calc_apparent_power_gain_ShouldReturnCalculatedGain) {
+	uint16_t gain;
+	expect_read("\xA5\x2C", "\x0A\x1F\x36\x94\x3B", 5);
+	expect_read("\xA5\x2E", "\x0A\x1F\x45\x26\x98", 5);
+	LONGS_EQUAL(HLW811X_ERROR_NONE, hlw811x_calc_apparent_power_gain(hlw811x, &gain));
+	LONGS_EQUAL(0xD7, gain);
+}
+
+TEST(HLW811x, calc_apparent_power_offset_ShouldReturnCalculatedOffset) {
+	uint16_t offset;
+	expect_read("\xA5\x2C", "\x00\x08\xC2\xD4\x90", 5);
+	expect_read("\xA5\x2E", "\x00\x08\xC1\xD7\x8C", 5);
+	LONGS_EQUAL(HLW811X_ERROR_NONE, hlw811x_calc_apparent_power_offset(hlw811x, &offset));
+	LONGS_EQUAL(0xFD, offset);
+}

--- a/tests/src/hlw811x_test.cpp
+++ b/tests/src/hlw811x_test.cpp
@@ -270,3 +270,34 @@ TEST(HLW811x, energy_ShouldReturn1Wh_When1WhIsGiven) {
 	LONGS_EQUAL(HLW811X_ERROR_NONE, hlw811x_get_energy(hlw811x, HLW811X_CHANNEL_A, &Wh));
 	LONGS_EQUAL(4194308, Wh); /* It should be 16777215. 0.0001192% error. */
 }
+
+TEST(HLW811x, apply_calibration_ShouldApplyCalibration) {
+	const struct hlw811x_calibration expected = {
+		.hfconst = 0x1234,
+		.pa_gain = 0x5678,
+		.pb_gain = 0x9ABC,
+		.phase_a = 0xDE,
+		.phase_b = 0xF0,
+		.paos = 0x1111,
+		.pbos = 0x2222,
+		.rms_iaos = 0x3333,
+		.rms_ibos = 0x4444,
+		.ib_gain = 0x5555,
+		.ps_gain = 0x6666,
+		.psos = 0x7777,
+	};
+
+	expect_write("\xA5\x82\x12\x34\x92", 5);
+	expect_write("\xA5\x85\x56\x78\x07", 5);
+	expect_write("\xA5\x86\x9A\xBC\x7E", 5);
+	expect_write("\xA5\x87\xDE\xF5", 4);
+	expect_write("\xA5\x88\xF0\xE2", 4);
+	expect_write("\xA5\x8A\x11\x11\xAE", 5);
+	expect_write("\xA5\x8B\x22\x22\x8B", 5);
+	expect_write("\xA5\x8E\x33\x33\x66", 5);
+	expect_write("\xA5\x8F\x44\x44\x43", 5);
+	expect_write("\xA5\x90\x55\x55\x20", 5);
+	expect_write("\xA5\x91\x66\x66\xFD", 5);
+	expect_write("\xA5\x92\x77\x77\xDA", 5);
+	LONGS_EQUAL(HLW811X_ERROR_NONE, hlw811x_apply_calibration(hlw811x, &expected));
+}


### PR DESCRIPTION
This pull request introduces a new feature to support calibration of the HLW811X device by adding a calibration structure and a corresponding function to apply calibration parameters. The main changes include the addition of a new `hlw811x_calibration` structure, the implementation of the `hlw811x_apply_calibration` function, and the corresponding documentation updates.

### New Calibration Feature:

* **New calibration structure**: Added a `hlw811x_calibration` structure to define calibration parameters such as pulse frequency constant, power gains, phase angles, offsets, and other related values. (`hlw811x.h`, [hlw811x.hR139-R153](diffhunk://#diff-21dcb5946cfc8c9963a6db1d7d47abcadd5f451ff3d9e8a1ef0f5bb95ca04f04R139-R153))
* **Calibration function**: Implemented the `hlw811x_apply_calibration` function to apply the calibration parameters to the HLW811X device. This function writes the provided calibration values to the appropriate HLW811X registers. (`hlw811x.c`, [hlw811x.cR1515-R1550](diffhunk://#diff-5d0610a8b7c534a9ee8924bb629ff29497744673dc8af8bfe3d901be71dcd0ccR1515-R1550))
* **Documentation updates**: Added documentation for the `hlw811x_apply_calibration` function, explaining its purpose, parameters, and return value. (`hlw811x.h`, [hlw811x.hR197-R211](diffhunk://#diff-21dcb5946cfc8c9963a6db1d7d47abcadd5f451ff3d9e8a1ef0f5bb95ca04f04R197-R211))